### PR TITLE
- Added a check in UICheckBox.cpp's onTouchEnded. The function now ch…

### DIFF
--- a/cocos/ui/UICheckBox.cpp
+++ b/cocos/ui/UICheckBox.cpp
@@ -23,6 +23,7 @@ THE SOFTWARE.
 ****************************************************************************/
 
 #include "ui/UICheckBox.h"
+#include "2d/CCCamera.h"
 
 NS_CC_BEGIN
 
@@ -96,18 +97,22 @@ CheckBox* CheckBox::create(const std::string& backGround,
     
 void CheckBox::onTouchEnded(Touch *touch, Event *unusedEvent)
 {
-    if (_isSelected)
-    {
-        setSelected(false);
-        AbstractCheckButton::onTouchEnded(touch, unusedEvent);
-        dispatchSelectChangedEvent(false);
-    }
-    else
-    {
-        setSelected(true);
-        AbstractCheckButton::onTouchEnded(touch, unusedEvent);
-        dispatchSelectChangedEvent(true);
-    }
+	_touchBeganPosition = touch->getLocation();
+	auto camera = Camera::getVisitingCamera();
+	if (hitTest(_touchBeganPosition, camera, nullptr)) {
+		if (_isSelected)
+		{
+			setSelected(false);
+			AbstractCheckButton::onTouchEnded(touch, unusedEvent);
+			dispatchSelectChangedEvent(false);
+		}
+		else
+		{
+			setSelected(true);
+			AbstractCheckButton::onTouchEnded(touch, unusedEvent);
+			dispatchSelectChangedEvent(true);
+		}
+	}
 }
     
 


### PR DESCRIPTION
…ecks whether the click release is within the bounds of the check box.

Without this fix, you can click inside of a checkbox, drag to the outside of it, and release. This will trigger a bug where the checkbox will look checked but never go through the "check" functionality and will therefore appear to be in an incorrect state.
